### PR TITLE
Add dynamic homepage app, chapter manifest, SVG hero and styles for Lore.Land

### DIFF
--- a/book/scripts/home/app.mjs
+++ b/book/scripts/home/app.mjs
@@ -1,0 +1,41 @@
+import { chapterManifest } from './data.mjs';
+import { renderHero, renderTimeline } from './ui.mjs';
+
+function setMoodStylesheet() {
+  const moodSelect = document.getElementById('mood-select');
+  const moodStyles = document.getElementById('mood-styles');
+
+  if (!moodSelect || !moodStyles) {
+    return;
+  }
+
+  const updateMood = () => {
+    const mood = moodSelect.value;
+    if (!mood) {
+      moodStyles.disabled = true;
+      moodStyles.removeAttribute('href');
+      document.body.dataset.mood = '';
+      return;
+    }
+
+    moodStyles.disabled = false;
+    moodStyles.href = `/book/styles/moods/${mood}.css`;
+    document.body.dataset.mood = mood;
+  };
+
+  moodSelect.addEventListener('change', updateMood);
+  updateMood();
+}
+
+function initHomepage() {
+  const homeRoot = document.getElementById('home-app');
+  if (!homeRoot) {
+    return;
+  }
+
+  renderHero(homeRoot, chapterManifest.length);
+  renderTimeline(homeRoot, chapterManifest);
+  setMoodStylesheet();
+}
+
+document.addEventListener('DOMContentLoaded', initHomepage);

--- a/book/scripts/home/data.mjs
+++ b/book/scripts/home/data.mjs
@@ -1,0 +1,24 @@
+export const spwPrelude = `#[canon]{
+  ~[series]{ title: "Lore.Land" chapters: 13 }
+  ^[intent]{ "tell the tale in Spw syntax" }
+}`;
+
+export const chapterManifest = [
+  { number: 1, title: 'Dawn in Boon.land', spw: '^[chapter/01]{ ("boon.land") [ <dawn>{ cactus wakes } ] }' },
+  { number: 2, title: 'The First Echo', spw: '^[chapter/02]{ ("bane.land") [ <echo>{ distant drums answer } ] }' },
+  { number: 3, title: 'Signals in the Sand', spw: '^[chapter/03]{ ?[signal]{ dunes whisper old routes } }' },
+  { number: 4, title: 'Crosswind Council', spw: '^[chapter/04]{ &[council]{ boon + bane negotiate } }' },
+  { number: 5, title: 'The Quiet Rift', spw: '^[chapter/05]{ ~[rift]{ calm outside, fracture within } }' },
+  { number: 6, title: 'Lanterns of Bonk City', spw: '^[chapter/06]{ ("bonk.city") [ ![lantern]{ streets ignite } ] }' },
+  { number: 7, title: 'Blueberry Oath', spw: '^[chapter/07]{ <oath>{ boof binds fate at the ball } }' },
+  { number: 8, title: 'Songs of the Watering Eye', spw: '^[chapter/08]{ #[song]{ memory resonates in water } }' },
+  { number: 9, title: 'Shards of Nine Honks', spw: '^[chapter/09]{ *[relic]{ nine honks scatter into night } }' },
+  { number: 10, title: 'Bone.land Resonance', spw: '^[chapter/10]{ ("bone.land") [ <concert>{ truth shakes the veil } ] }' },
+  { number: 11, title: 'Paradox Bloom', spw: '^[chapter/11]{ ~[paradox]{ impossible paths flower } }' },
+  { number: 12, title: 'The Last Confluence', spw: '^[chapter/12]{ &[confluence]{ all threads merge } }' },
+  { number: 13, title: 'Lore.Land Canon', spw: '^[chapter/13]{ ^[canon]{ world records itself and loops } }' }
+];
+
+export function chapterHref(number) {
+  return `/book/chapter/${String(number).padStart(2, '0')}`;
+}

--- a/book/scripts/home/svg.mjs
+++ b/book/scripts/home/svg.mjs
@@ -1,0 +1,47 @@
+const NS = 'http://www.w3.org/2000/svg';
+
+function createSvgNode(tag, attrs = {}) {
+  const node = document.createElementNS(NS, tag);
+  Object.entries(attrs).forEach(([key, value]) => node.setAttribute(key, value));
+  return node;
+}
+
+export function createFrameSvg() {
+  const svg = createSvgNode('svg', {
+    viewBox: '0 0 1200 320',
+    class: 'hero-frame-svg',
+    'aria-hidden': 'true'
+  });
+
+  const defs = createSvgNode('defs');
+  const gradient = createSvgNode('linearGradient', { id: 'flowGradient', x1: '0%', y1: '0%', x2: '100%', y2: '0%' });
+  gradient.append(
+    createSvgNode('stop', { offset: '0%', 'stop-color': '#88ffe8' }),
+    createSvgNode('stop', { offset: '50%', 'stop-color': '#79a8ff' }),
+    createSvgNode('stop', { offset: '100%', 'stop-color': '#c990ff' })
+  );
+
+  defs.append(gradient);
+  svg.append(defs);
+
+  svg.append(
+    createSvgNode('path', {
+      d: 'M32 180 C 220 64, 380 256, 560 160 S 920 66, 1168 174',
+      fill: 'none',
+      stroke: 'url(#flowGradient)',
+      'stroke-width': '6',
+      'stroke-linecap': 'round',
+      opacity: '0.8'
+    }),
+    createSvgNode('path', {
+      d: 'M32 240 C 200 126, 380 310, 560 216 S 920 122, 1168 234',
+      fill: 'none',
+      stroke: 'url(#flowGradient)',
+      'stroke-width': '2',
+      'stroke-linecap': 'round',
+      opacity: '0.45'
+    })
+  );
+
+  return svg;
+}

--- a/book/scripts/home/ui.mjs
+++ b/book/scripts/home/ui.mjs
@@ -1,0 +1,62 @@
+import { chapterHref, spwPrelude } from './data.mjs';
+import { createFrameSvg } from './svg.mjs';
+
+export function renderHero(root, chapterCount) {
+  const panel = document.createElement('section');
+  panel.className = 'hero-panel';
+
+  const eyebrow = document.createElement('p');
+  eyebrow.className = 'hero-eyebrow';
+  eyebrow.textContent = 'Spw Story Architecture';
+
+  const title = document.createElement('h1');
+  title.textContent = 'Lore.Land — 13 Chapters in Spw';
+
+  const subtitle = document.createElement('p');
+  subtitle.className = 'hero-subtitle';
+  subtitle.textContent =
+    'An abstract reading frame where each chapter opens as a compact Spw scene.';
+
+  const stats = document.createElement('p');
+  stats.className = 'hero-stats';
+  stats.textContent = `${chapterCount} chapters • semantic flow • canonical timeline`;
+
+  const prelude = document.createElement('pre');
+  prelude.className = 'spw-block';
+  prelude.textContent = spwPrelude;
+
+  panel.append(eyebrow, title, subtitle, stats, prelude, createFrameSvg());
+  root.append(panel);
+}
+
+export function renderTimeline(root, chapters) {
+  const section = document.createElement('section');
+  section.className = 'chapter-grid';
+  section.setAttribute('aria-label', 'Thirteen chapter story flow');
+
+  chapters.forEach((chapter) => {
+    const card = document.createElement('article');
+    card.className = 'chapter-card';
+
+    const marker = document.createElement('span');
+    marker.className = 'chapter-marker';
+    marker.textContent = String(chapter.number).padStart(2, '0');
+
+    const heading = document.createElement('h2');
+    heading.textContent = chapter.title;
+
+    const snippet = document.createElement('pre');
+    snippet.className = 'spw-snippet';
+    snippet.textContent = chapter.spw;
+
+    const link = document.createElement('a');
+    link.href = chapterHref(chapter.number);
+    link.textContent = 'Open chapter';
+    link.setAttribute('aria-label', `Open chapter ${chapter.number}: ${chapter.title}`);
+
+    card.append(marker, heading, snippet, link);
+    section.append(card);
+  });
+
+  root.append(section);
+}

--- a/book/styles/fixtures/home.css
+++ b/book/styles/fixtures/home.css
@@ -1,0 +1,134 @@
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1d2442 0%, #0a0e1f 52%, #090b16 100%);
+  color: #e7ebff;
+  padding: 2rem;
+}
+
+.site-shell {
+  max-width: 1080px;
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.site-topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.site-topbar a {
+  color: #f4f7ff;
+}
+
+.hero-panel {
+  position: relative;
+  padding: 2rem;
+  border: 1px solid rgba(184, 205, 255, 0.3);
+  border-radius: 20px;
+  background: linear-gradient(160deg, rgba(138, 159, 255, 0.16), rgba(107, 188, 220, 0.08));
+  overflow: hidden;
+}
+
+.hero-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.8rem;
+  margin-bottom: 0.5rem;
+  color: #9cd7ff;
+}
+
+.hero-subtitle,
+.hero-stats {
+  max-width: 65ch;
+  color: #c8d4ff;
+}
+
+.hero-stats {
+  margin-top: 0.8rem;
+  font-size: 0.95rem;
+}
+
+.spw-block,
+.spw-snippet {
+  font-family: JetBrainsMono, ui-monospace, SFMono-Regular, Menlo, monospace;
+  white-space: pre-wrap;
+  border: 1px solid rgba(153, 255, 247, 0.28);
+  background: rgba(3, 7, 24, 0.62);
+  border-radius: 10px;
+}
+
+.spw-block {
+  margin-top: 1rem;
+  padding: 0.8rem;
+  color: #b5fff5;
+}
+
+.spw-snippet {
+  margin: 0;
+  padding: 0.65rem;
+  color: #9fe6ff;
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
+.hero-frame-svg {
+  display: block;
+  width: 100%;
+  height: 180px;
+  margin-top: 1rem;
+}
+
+.chapter-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.chapter-card {
+  border: 1px solid rgba(156, 215, 255, 0.3);
+  border-radius: 14px;
+  background: rgba(10, 15, 38, 0.75);
+  padding: 1rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.chapter-marker {
+  width: fit-content;
+  border-radius: 999px;
+  border: 1px solid rgba(153, 255, 247, 0.5);
+  color: #99fff7;
+  font-size: 0.82rem;
+  padding: 0.1rem 0.5rem;
+}
+
+.chapter-card h2 {
+  font-size: 1.1rem;
+  margin: 0;
+  color: #f7f9ff;
+}
+
+.chapter-card a {
+  color: #9cd7ff;
+  font-weight: 600;
+}
+
+.site-footer {
+  padding: 1rem 0 0.5rem;
+  color: #b3bee5;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1rem;
+  }
+
+  .hero-panel {
+    padding: 1.25rem;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,73 +1,43 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Welcome to Lore.Land</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Lore.Land • 13 Chapter Spw Storytelling Flow</title>
+  <meta name="description" content="Lore.Land is a 13 chapter storytelling site with a modular Spw storytelling architecture and abstract reading frame.">
 
-    <!-- Structured Data for SEO -->
-    <script type="application/ld+json">
-        {
-            "@context": "https://schema.org",
-            "@type": "WebSite",
-            "name": "Lore.Land",
-            "alternateName": ["Lore.Land", "Lore.Land Homepage"],
-            "url": "https://lore.land/"
-        }
-    </script>
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "Lore.Land",
+      "url": "https://lore.land/"
+    }
+  </script>
 
-    <!-- Stylesheets -->
-    <link rel="stylesheet" href="/book/styles/fixtures/root.css?v=2024_10_04.G">
-    <link rel="stylesheet" href="/book/styles/fixtures/fonts.css">
-    <link rel="stylesheet" href="/book/styles/fixtures/identities.css">
-    <link id="period-styles" rel="stylesheet">
-    <link id="mood-styles" rel="stylesheet">
-
-    <!-- JavaScript -->
-    <script defer type="module" src="/book/scripts/modules/ebook.mjs?v=2024_10_04.G"></script>
-    <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        const chaptersList = document.getElementById('chapters-list');
-        for (let i = 1; i <= 13; i++) {
-          const chapterItem = document.createElement('li');
-          const chapterLink = document.createElement('a');
-          chapterLink.href = `/book/chapter/${String(i).padStart(2, '0')}`;
-          chapterLink.textContent = `Chapter ${i}`;
-          chapterItem.appendChild(chapterLink);
-          chaptersList.appendChild(chapterItem);
-        }
-      });
-    </script>
+  <link rel="stylesheet" href="/book/styles/fixtures/fonts.css">
+  <link rel="stylesheet" href="/book/styles/fixtures/home.css?v=2026_02_28.A">
+  <link id="mood-styles" rel="stylesheet">
+  <script defer type="module" src="/book/scripts/home/app.mjs?v=2026_02_28.A"></script>
 </head>
 <body data-mood="">
-<main>
-    <h1>
-        <span>Welcome to</span>&nbsp;
-        <a href="/#" aria-label="Home page of Lore.Land">Lore.Land</a>
-    </h1>
+  <div class="site-shell">
+    <header class="site-topbar">
+      <a href="/#" aria-label="Lore.Land homepage">Lore.Land</a>
+      <label for="mood-select">
+        <span>Mood:</span>
+        <select id="mood-select" aria-label="Select reading mood">
+          <option selected value="">default</option>
+          <option value="tldr">tl;dr</option>
+        </select>
+      </label>
+    </header>
 
-    <aside>
-        <label for="mood-select">
-            <span>Mood:</span>
-            <select id="mood-select" aria-label="Select mood">
-                <option selected value=""></option>
-                <option value="tldr">tl;dr</option>
-            </select>
-        </label>
-    </aside>
-</main>
+    <main id="home-app" aria-live="polite"></main>
 
-<article id="book">
-    <h2>The Tale of Lore.Land</h2>
-    <h3>Chapters</h3>
-    <nav aria-label="Table of contents">
-        <ul id="chapters-list"></ul>
-    </nav>
-</article>
-
-<footer>
-    This site was crafted by&nbsp;
-    <a href="https://spwashi.com/?from=lore.land" aria-label="Visit spwashi's personal site">spwashi</a>
-</footer>
+    <footer class="site-footer">
+      Crafted by <a href="https://spwashi.com/?from=lore.land" aria-label="Visit spwashi site">spwashi</a>
+    </footer>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace the static index landing markup with a structured, script-driven homepage that presents the 13-chapter Spw story flow and an abstract reading frame.
- Provide a programmatic chapter manifest and helper to generate chapter links for rendering the timeline and snippets.
- Introduce a dynamic mood stylesheet switcher so readers can toggle reading moods and load corresponding CSS.

### Description
- Updated `index.html` to new homepage layout, added `home.css` and wired the client module `book/scripts/home/app.mjs` to initialize the page and mood selector.
- Added `book/scripts/home/data.mjs` exporting `spwPrelude`, `chapterManifest`, and `chapterHref` to centralize chapter metadata and link generation.
- Implemented `book/scripts/home/ui.mjs` which renders the hero panel (including the Spw prelude) and the chapter timeline grid into `#home-app` using DOM construction.
- Implemented `book/scripts/home/svg.mjs` to generate an inline decorative SVG hero frame, and added `book/styles/fixtures/home.css` with styles for the new layout and components.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a278bff210832191aa1767970deafa)